### PR TITLE
Replace deprecated airport command with system_profiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
                 "normalize.css": "^8.0.1",
                 "react": "^18.3.0",
                 "react-dom": "^18.3.0",
-                "rgb-hex": "^2.1.0",
-                "split": "^1.0.1"
+                "rgb-hex": "^2.1.0"
             },
             "devDependencies": {
                 "@electron-forge/cli": "^7.10.2",
@@ -13237,18 +13236,6 @@
             "dev": true,
             "license": "CC0-1.0"
         },
-        "node_modules/split": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-            "license": "MIT",
-            "dependencies": {
-                "through": "2"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/ssri": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
@@ -13663,12 +13650,6 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/through": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
             "license": "MIT"
         },
         "node_modules/tiny-each-async": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
         "normalize.css": "^8.0.1",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
-        "rgb-hex": "^2.1.0",
-        "split": "^1.0.1"
+        "rgb-hex": "^2.1.0"
     },
     "devDependencies": {
         "@electron-forge/cli": "^7.10.2",

--- a/src/types/split.d.ts
+++ b/src/types/split.d.ts
@@ -1,5 +1,0 @@
-declare module 'split' {
-    import { Transform } from 'stream';
-    function split(matcher?: RegExp | string): Transform;
-    export = split;
-}


### PR DESCRIPTION
## Summary

- Replace the deprecated `airport` CLI (removed in macOS Sonoma) with `system_profiler SPAirPortDataType`
- Parse JSON output for reliable WiFi data extraction
- Remove the `split` dependency (no longer needed)
- Increase default poll interval to 2000ms (system_profiler is slower than airport)

## Changes

- Rewrote `wifi.ts` to use `exec` with `system_profiler SPAirPortDataType -json`
- Added new parsing functions: `parseSignalNoise`, `parseChannel`, `parseSystemProfilerData`
- Updated tests to cover the new parsing logic (12 tests for wifi module)
- Removed `split` dependency and its type declaration

## Test plan

- [x] `npm run start` - app launches without ENOENT error
- [x] `npm run test` - 20 tests pass
- [x] `npm run typecheck` - no type errors
- [x] `npm run lint` - no linting errors
- [x] `npm run format:check` - formatting passes

Closes #21