### PR TITLE
Fix WiFi monitoring not starting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow } from 'electron';
 import path from 'path';
-import wifi from './wifi';
+import wifi, { start as startWifi, stop as stopWifi } from './wifi';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
@@ -37,9 +37,13 @@ function createWindow(): void {
     monitor(mainWindow);
 }
 
-app.on('ready', createWindow);
+app.on('ready', () => {
+    createWindow();
+    startWifi();
+});
 
 app.on('window-all-closed', () => {
+    stopWifi();
     if (process.platform !== 'darwin') {
         app.quit();
     }


### PR DESCRIPTION
## Summary

- Fix WiFi monitoring not starting after the system_profiler migration
- Call `startWifi()` when the app is ready
- Call `stopWifi()` when all windows are closed

## Problem

After PR #22 removed the auto-start code from wifi.ts, the WiFi monitoring was never started, causing the app to show 0 values for all metrics.

## Test plan

- [x] `npm run start` - app displays WiFi data correctly
- [x] `npm run test` - 20 tests pass
- [x] `npm run typecheck` - no type errors
- [x] `npm run lint` - no linting errors
- [x] `npm run format:check` - formatting passes

Closes #23